### PR TITLE
Mitigate focus race condition for editor terminal

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,7 +30,9 @@ function launchTvTerminal(tv_command: string, cwd: vscode.Uri) {
     cwd: cwd,
   });
   log("Terminal created");
-  terminal.show();
+  terminal.show(); // This is supposed to also focus on the terminal, but occasionally fails
+  // Explicitly focus the editor group to mitigate focus race conditions
+  vscode.commands.executeCommand('workbench.action.focusActiveEditorGroup');
   return { terminal, tvFile: TV_TEMP_FILE };
 }
 


### PR DESCRIPTION
**Problem:**
When launching the TV Finder terminal it frequently fails to gain keyboard focus despite the `terminal.show()` call. This requires users to manually click the terminal or toggle the finder off and on again and hope it focuses correctly the second time.

**Cause:**
This appears to be caused by a timing issue or race condition within VS Code. The `terminal.show()` call correctly makes the terminal visible, but the focus transfer doesn't always complete successfully.

**Solution:**
This PR introduces an explicit command execution immediately after `terminal.show()` in the `launchTvTerminal` function:

```typescript
// Explicitly focus the editor group to mitigate focus race conditions
vscode.commands.executeCommand('workbench.action.focusActiveEditorGroup');
```

By explicitly commanding VS Code to focus the active editor group (where the terminal just appeared), we significantly increase the likelihood that the terminal receives keyboard focus reliably.

**Testing:**
1.  Build the extension with this change.
2.  Reload the VS Code window.
3.  Repeatedly use the keybinding (`ctrl+p`) to toggle the TV Finder.
4.  Observe that the terminal window now consistently receives focus immediately after opening.

So far I have not observed this problem anymore after making the change, although it's been recent so I can't say with 100% certainty.