### PR TITLE
feat: Refocus editor after the terminal closes

### DIFF
--- a/src/channels/generic.ts
+++ b/src/channels/generic.ts
@@ -30,7 +30,7 @@ export async function genericHandler(
   // launch TV in new terminal
   const { terminal, tvFile } = launchTvTerminal(tv_command, workspaceFolder);
   // Listen for terminal close, but only for this specific terminal
-  const closeListener = vscode.window.onDidCloseTerminal(async (t) => {
+  const closeListener = vscode.window.onDidCloseTerminal(async (t: vscode.Terminal) => {
     if (t === terminal) {
       // Ensure it's our terminal
       info(`${name} terminal closed`);
@@ -44,6 +44,8 @@ export async function genericHandler(
           vscode.window.showErrorMessage(`Failed to open files: ${error}`);
         }
       }
+      // Refocus the editor group
+      vscode.commands.executeCommand('workbench.action.focusActiveEditorGroup');
       // Cleanup: Remove event listener after terminal is handled
       closeListener.dispose();
     }


### PR DESCRIPTION
### Description

This pull request improves the UX for the terminal launched by focus back to editor group when terminal is closed

### Problem

When a terminal associated with a generic channel task is closed (either manually by the user or upon task completion), the editor focus might remain on the (now potentially empty) terminal panel or become unclear. If the channel handler is configured to open related files upon closure (e.g., log files), the user has to manually click back into the editor group to view them.

### Changes proposed in this PR
1.  Added a call to focus active editor group in listener to ensures that immediately after the terminal is closed, the focus shifts back to the active editor group.
2.  Added an explicit type to fix `any` type