### PR TITLE
feat: support find text (grep) with selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,11 +27,18 @@
     "commands": [
       {
         "command": "television.ToggleFileFinder",
-        "title": "Television: Toggle File Finder"
+        "title": "Television: Toggle File Finder",
+        "category": "Television"
       },
       {
         "command": "television.ToggleTextFinder",
-        "title": "Television: Toggle Text Finder"
+        "title": "Television: Toggle Text Finder (grep)",
+        "category": "Television"
+      },
+      {
+        "command": "television.ToggleTextFinderWithSelection",
+        "title": "Television: Toggle Text Finder with Current Selection",
+        "category": "Television"
       }
     ],
     "keybindings": [

--- a/src/channels/text.ts
+++ b/src/channels/text.ts
@@ -1,8 +1,30 @@
 import { openFilesAtLines } from "../utils";
 import { genericHandler } from "./generic";
+import * as vscode from "vscode";
 
 const TELEVISION_COMMAND = "tv --no-remote text";
 
 export async function textHandler() {
   genericHandler("TV Text", TELEVISION_COMMAND, openFilesAtLines);
+}
+
+export async function textHandlerWithSelection() {
+  const editor = vscode.window.activeTextEditor;
+  let command = TELEVISION_COMMAND;
+
+  if (editor) {
+    const selection = editor.selection;
+    const selectedText = editor.document.getText(selection);
+    if (selectedText && !selection.isEmpty) {
+      // Escape for shell inside single quotes: \ -> \\ and ' -> \'
+      const escapedQuery = selectedText
+        .replace(/\\/g, "\\\\") // Escape backslashes first
+        .replace(/'/g, "\\'"); // Escape single quotes
+
+      // Append the input argument and the escaped value
+      command = `${TELEVISION_COMMAND} --input ${escapedQuery}`;
+    }
+  }
+
+  genericHandler("TV Text", command, openFilesAtLines);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import {
   warnBinaryNotFound,
 } from "./binary";
 import { filesHandler } from "./channels/files";
-import { textHandler } from "./channels/text";
+import { textHandler, textHandlerWithSelection } from "./channels/text";
 
 export async function activate(context: {
   subscriptions: vscode.Disposable[];
@@ -40,6 +40,14 @@ export async function activate(context: {
   disposable = vscode.commands.registerCommand(
     "television.ToggleTextFinder",
     textHandler,
+  );
+  context.subscriptions.push(disposable);
+  // Text with Selection
+  // -------------------------------------------------------------------------
+  info("Registering ToggleTextFinderWithSelection command");
+  disposable = vscode.commands.registerCommand(
+    "television.ToggleTextFinderWithSelection",
+    textHandlerWithSelection,
   );
   context.subscriptions.push(disposable);
 }


### PR DESCRIPTION
# Description:
Adds Text Search with Selection: Introduces a new command to initiate a text search using the currently selected text in the active editor as the initial search query.

# Changes Made:
New Command: Text Search with Selection:
- Defined a new command `television.ToggleTextFinderWithSelection` with the title "Television: Toggle Text Finder with Current Selection" in `package.json`.
- Created a new handler function `textHandlerWithSelection` in src/channels/text.ts.
- This handler retrieves the selected text from the active editor.
- It constructs the `tv text` command using the `--input` argument (identified as the correct argument via tv text --help) to pre-fill the search prompt.
- Includes logic to correctly escape special characters (like quotes and backslashes) in the selected text for safe shell execution via sh -c.
- Registered the new command and handler in src/extension.ts.

# Test:
![CleanShot 2025-05-03 at 18 30 39](https://github.com/user-attachments/assets/9092cb41-744a-4018-94b5-422dbbad599b)

# Tips:
Add this mapping to enable text search at the current word where the cursor is positioned:
```
    {
      "before": ["space", "f", "w"],
      "commands": [
        {
          "command": "editor.action.addSelectionToNextFindMatch",
          "when": "editorTextFocus && !editorHasSelection"
        },
        "television.ToggleTextFinderWithSelection"
      ]
    }
```