### PR TITLE
Clarify installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ PATH.
 
 Installation instructions may be found [here](https://github.com/alexpasmantier/television/wiki/Installation).
 
+For example,installing on Homebrew can be done as follows:
+```bash
+brew install television
+```
+
+Once installed, run the command below, which will install the `files` and `text` channels that are required by the extension.
+
+```bash
+tv update-channels
+```
+
+See [television](https://github.com/alexpasmantier/television) for more details.
+
 ## Default keybindings
 
 Television comes with the following keybindings:


### PR DESCRIPTION
The  extension requires `text` channel which took me awhile to figure out. The README should guide the user to make sure the `files` and `text` channels are installed or else you will experience errors like `The terminal process "sh '-c', 'tv --no-remote text > /var/folders/4n/6mnm6cw94yq_yhfvcxxft3180000gp/T/tv_selection'" failed to launch (exit code: 1).` when running the grep.